### PR TITLE
Advisory for Cookie settings where SameSite is None and secure is false

### DIFF
--- a/config/circlical.user.local.php.dist
+++ b/config/circlical.user.local.php.dist
@@ -78,7 +78,7 @@ return [
                 /*
                  * What SameSite policy do we give cookies?  Can be set to null 'Strict, 'Lax' or 'None'
                  */
-                'samesite_policy' => 'lax',
+                'samesite_policy' => 'Lax',
 
                 /*
                  * Forgot password functionality

--- a/config/circlical.user.local.php.dist
+++ b/config/circlical.user.local.php.dist
@@ -78,7 +78,7 @@ return [
                 /*
                  * What SameSite policy do we give cookies?  Can be set to null 'Strict, 'Lax' or 'None'
                  */
-                'samesite_policy' => 'None',
+                'samesite_policy' => 'lax',
 
                 /*
                  * Forgot password functionality


### PR DESCRIPTION
In circlical.user.local.php.dist I will change the initial settings to:
```
'secure_cookies'        => false,               
'samesite_policy'       => 'Lax',
```